### PR TITLE
Bugfix: Use senderName in sender configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = {
 
           const msg = {
             sender: {
-              name: from || settings.defaultSenderName,
+              name: senderName,
               email: senderEmail,
             },
             to: [{ email: to }],


### PR DESCRIPTION
Without the fix, the sender name will always be set to the from email, not the provided name or default name.